### PR TITLE
FIX: Scroll arrow is visible from hero again

### DIFF
--- a/app/assets/stylesheets/components/_fonts.scss
+++ b/app/assets/stylesheets/components/_fonts.scss
@@ -37,5 +37,5 @@ p {
   font-family: Montserrat, sans-serif;
   font-size: 12px;
   font-weight: 600;
-  color: rgb(248, 248, 248);
+  color: #1C1A20;
 }

--- a/app/assets/stylesheets/components/_intro.scss
+++ b/app/assets/stylesheets/components/_intro.scss
@@ -53,11 +53,11 @@
 
 .scroll-arrow {
   position: absolute;
-  top: 85%;
-  left: calc(50% - 24px);
+  top: 88%;
+  left: calc(50% + 24px);
   transform: translate(-50%, -50%);
   text-align: center;
-  color: rgb(248, 248, 248);
+  color: #1C1A20;
 }
 
 .scroll-text {


### PR DESCRIPTION
After scrolling, the hero image covers the scroll arrow, making any animation redundant. Therefore, no animation was added to the arrow.